### PR TITLE
WIP: Add stuff for a nix-based development environment

### DIFF
--- a/nixpkgs-version.json
+++ b/nixpkgs-version.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/nixos/nixpkgs-channels.git",
+  "rev": "76fad4511050e36adbcc54b39034a4a082798f13",
+  "date": "2019-05-02T18:59:59+02:00",
+  "sha256": "1c06id9202bn22vznyfx1y081w3yzajiplqwb74pl6iap8ijr36s",
+  "fetchSubmodules": false
+}

--- a/pinned-nixpkgs.nix
+++ b/pinned-nixpkgs.nix
@@ -1,0 +1,12 @@
+let
+   hostPkgs = import <nixpkgs> {};
+   # Generated through:
+   # nix-shell -p nix-prefetch-git --run "nix-prefetch-git  https://github.com/nixos/nixpkgs-channels.git --rev {rev} > nixpkgs-version.json"
+   pinnedVersion = hostPkgs.lib.importJSON ./nixpkgs-version.json;
+
+   pinnedPkgs = hostPkgs.fetchFromGitHub {
+     owner = "NixOS";
+     repo = "nixpkgs-channels";
+     inherit (pinnedVersion) rev sha256;
+   };
+ in pinnedPkgs

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+let pinned-nixpkgs-path = import ./pinned-nixpkgs.nix;
+    pinned-pkgs = import pinned-nixpkgs-path {};
+in { pkgs ? pinned-pkgs }:
+
+with pkgs;
+
+mkShell {
+  buildInputs = [ stack haskellPackages.ghcid ];
+  NIX_PATH="nixpkgs=${pinned-nixpkgs-path}";
+}


### PR DESCRIPTION
Adds ability for a nix user to run `nix-shell` to drop into an environment with stack and ghcid.

Later we could also set things up to build using nix fairly easily, though as long as this is a pure haskell project there's almost certainly not much benefit to that.